### PR TITLE
Add bin script to package the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "files": [
     "dist/**/*",
+    "_templates/**/*",
     "README.md"
   ],
   "keywords": [

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,9 +3,12 @@
 const { runner } = require('hygen');
 const Logger = require('hygen/lib/logger');
 const path = require('path');
-const defaultTemplates = path.join(__dirname, 'templates');
 
-runner(process.argv.slice(2), {
+// These templates will be included in the package
+const defaultTemplates = path.join(__dirname, '..', '_templates');
+
+// Use compeller command always
+runner(['compeller', ...process.argv.slice(2)], {
   templates: defaultTemplates,
   cwd: process.cwd(),
   logger: new Logger(console.log.bind(console)),


### PR DESCRIPTION
This will fulfill the usage of compeller to invoke:

```ts
npx compeller new
```

It would be weird of compeller to inject json-schema-to-ts, but also, re-exporting it will be strange, and can lead to the double version issue in package managers.

Suggest for now we can list it as an unmet dependency, or have the injection approved.