### PR TITLE
feat: add response header support for responders where headers are optional in response but keys are required when added

### DIFF
--- a/examples/headers/api-gateway.ts
+++ b/examples/headers/api-gateway.ts
@@ -1,0 +1,19 @@
+import { APIGatewayV1Responder, compeller } from '../../src';
+import { OpenAPISpecification } from './openapi/spec';
+
+const apiGatewayV1Compeller = compeller(OpenAPISpecification, {
+  responder: APIGatewayV1Responder,
+});
+
+console.info(
+  apiGatewayV1Compeller('v1/version', 'get').response(
+    '200',
+    {
+      version: '1.0.0',
+    },
+    {
+      'x-request-id': '<uuid>',
+      'x-rate-limit': 120,
+    }
+  )
+);

--- a/examples/headers/api-gateway.ts
+++ b/examples/headers/api-gateway.ts
@@ -14,6 +14,7 @@ console.info(
     {
       'x-request-id': '<uuid>',
       'x-rate-limit': 120,
+      'Content-Type': 'application/json',
     }
   )
 );

--- a/examples/headers/custom.ts
+++ b/examples/headers/custom.ts
@@ -24,6 +24,7 @@ console.info(
     {
       'x-rate-limit': 120,
       'x-request-id': '<uuid>',
+      'Content-Type': 'application/json',
     }
   )
 );

--- a/examples/headers/custom.ts
+++ b/examples/headers/custom.ts
@@ -16,7 +16,14 @@ const customerCompeller = compeller(OpenAPISpecification, {
 });
 
 console.info(
-  customerCompeller('v1/version', 'get').response('200', {
-    version: '1.0.0',
-  })
+  customerCompeller('v1/version', 'get').response(
+    '200',
+    {
+      version: '1.0.0',
+    },
+    {
+      'x-rate-limit': 120,
+      'x-request-id': '<uuid>',
+    }
+  )
 );

--- a/examples/headers/default.ts
+++ b/examples/headers/default.ts
@@ -3,15 +3,15 @@ import { OpenAPISpecification } from './openapi/spec';
 
 const defaultCompeller = compeller(OpenAPISpecification);
 
-console.info(
-  defaultCompeller('v1/version', 'get').response(
-    '200',
-    {
-      version: '1.0.0',
-    },
-    {
-      'x-rate-limit': 123,
-      'x-request-id': '<uuid>',
-    }
-  )
+const res = defaultCompeller('v1/version', 'get').response(
+  '200',
+  {
+    version: '1.0.0',
+  },
+  {
+    'x-rate-limit': 123,
+    'x-request-id': 'uuid',
+  }
 );
+
+console.info('Formatted default response', res);

--- a/examples/headers/default.ts
+++ b/examples/headers/default.ts
@@ -11,6 +11,7 @@ const res = defaultCompeller('v1/version', 'get').response(
   {
     'x-rate-limit': 123,
     'x-request-id': 'uuid',
+    'Content-Type': 'application/json',
   }
 );
 

--- a/examples/headers/default.ts
+++ b/examples/headers/default.ts
@@ -1,0 +1,17 @@
+import { compeller } from '../../src';
+import { OpenAPISpecification } from './openapi/spec';
+
+const defaultCompeller = compeller(OpenAPISpecification);
+
+console.info(
+  defaultCompeller('v1/version', 'get').response(
+    '200',
+    {
+      version: '1.0.0',
+    },
+    {
+      'x-rate-limit': 123,
+      'x-request-id': '<uuid>',
+    }
+  )
+);

--- a/examples/headers/openapi/spec.ts
+++ b/examples/headers/openapi/spec.ts
@@ -1,0 +1,49 @@
+import { OpenAPIObject } from 'openapi3-ts';
+
+export const OpenAPISpecification = {
+  info: {
+    title: 'New API generated with compeller',
+    version: '1.0.0',
+  },
+  openapi: '3.1.0',
+  paths: {
+    'v1/version': {
+      get: {
+        responses: {
+          '200': {
+            description: 'Get the current API version',
+            headers: {
+              'x-rate-limit': {
+                description:
+                  'The number of allowed requests in the current period',
+                schema: {
+                  type: 'number',
+                } as const,
+              },
+              'x-request-id': {
+                description: 'The unique request id header',
+                schema: {
+                  type: 'string',
+                } as const,
+              },
+            },
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['version'],
+                  additionalProperties: false,
+                  properties: {
+                    version: {
+                      type: 'string',
+                    },
+                  },
+                } as const,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/examples/standalone/default.ts
+++ b/examples/standalone/default.ts
@@ -1,4 +1,4 @@
-import { compeller } from '../src';
+import { compeller } from '../../src';
 import { OpenAPISpecification } from './openapi/spec';
 
 const defaultCompeller = compeller(OpenAPISpecification);

--- a/examples/with-cdk/src/openapi/compeller.ts
+++ b/examples/with-cdk/src/openapi/compeller.ts
@@ -1,5 +1,4 @@
-import { compeller } from 'compeller/dist/compeller/index';
-import { APIGatewayV1Responder } from 'compeller';
+import { compeller, APIGatewayV1Responder } from 'compeller';
 import { OpenAPISpecification } from './spec';
 
 export const compelled = compeller(OpenAPISpecification, {

--- a/src/compeller/index.ts
+++ b/src/compeller/index.ts
@@ -90,14 +90,13 @@ export const compeller = <
     const path = route as string;
 
     /**
-     * TODO - Responders need to handle headers
      *
      * Build a response object for the API with the required status and body
      * format
      *
      * @param statusCode The response code that the API returns
-     * @param body The JSON body for the API that is associated with that
-     * response code
+     * @param body The JSON body for the API that is associated with that response code
+     * @param headers The key, value map of the headers required for the response
      *
      * @returns
      */
@@ -111,7 +110,9 @@ export const compeller = <
           ? string
           : ResponseHeadersAlias[U]['schema']['type'] extends 'number'
           ? number
-          : boolean;
+          : ResponseHeadersAlias[U]['schema']['type'] extends 'boolean'
+          ? boolean
+          : never;
       }
     >(
       statusCode: ResponseCode,
@@ -142,12 +143,12 @@ export const compeller = <
         } = {},
       } = spec.paths[path][method];
 
-      // TODO: We need to handle the request not a requestBody
+      // TODO: We need to handle the request which do not have a requestBody
       //
       // Some users might abstract the functional components into a generic
       // wrapper, therefore gets might hit the validator path
       //
-      // We don't want to loose type safety
+      // We don't want to lose type safety
       const unsafeSchema = (schema || {}) as JSONSchemaType<FromSchema<SC>>;
 
       const ajv = new Ajv({

--- a/src/compeller/index.ts
+++ b/src/compeller/index.ts
@@ -113,7 +113,7 @@ export const compeller = <
           : ResponseHeadersAlias[U]['schema']['type'] extends 'boolean'
           ? boolean
           : never;
-      }
+      } & { 'Content-Type': ContentType }
     >(
       statusCode: ResponseCode,
       body: FromSchema<ResponseSchema>,

--- a/src/compeller/responders/aws/api-gateway-v1.test.ts
+++ b/src/compeller/responders/aws/api-gateway-v1.test.ts
@@ -13,13 +13,19 @@ describe('APIGatewayV1Responder', () => {
   });
 
   it('allows for header injection', () => {
-    const responder = APIGatewayV1Responder<200, { name: string }>(
+    const responder = APIGatewayV1Responder<
+      200,
+      { name: string },
+      {
+        'x-sample-header': string;
+      }
+    >(
       200,
       {
         name: 'Simon',
       },
       {
-        'x-sample-header': 'sample;',
+        'x-sample-header': 'sampled;',
       }
     );
 
@@ -27,7 +33,7 @@ describe('APIGatewayV1Responder', () => {
       statusCode: 200,
       body: JSON.stringify({ name: 'Simon' }),
       headers: {
-        'x-sample-header': 'sample;',
+        'x-sample-header': 'sampled;',
       },
     });
   });

--- a/src/compeller/responders/aws/api-gateway-v1.ts
+++ b/src/compeller/responders/aws/api-gateway-v1.ts
@@ -3,13 +3,14 @@ import { ICompellerOptions } from '../..';
 
 export const APIGatewayV1Responder: ICompellerOptions['responder'] = <
   T extends string | number | symbol,
-  U
+  U,
+  V extends { [header: string]: string | number | boolean }
 >(
   statusCode: T,
   body: U,
-  headers: APIGatewayProxyResult['headers'],
-  isBase64Encoded: APIGatewayProxyResult['isBase64Encoded'],
-  multiValueHeaders: APIGatewayProxyResult['multiValueHeaders']
+  headers?: V,
+  isBase64Encoded?: APIGatewayProxyResult['isBase64Encoded'],
+  multiValueHeaders?: APIGatewayProxyResult['multiValueHeaders']
 ): APIGatewayProxyResult => {
   if (typeof statusCode === 'number') {
     return {

--- a/src/compeller/responders/default/index.ts
+++ b/src/compeller/responders/default/index.ts
@@ -1,9 +1,15 @@
 import { ICompellerOptions } from '../..';
 
-export const defaultResponder: ICompellerOptions['responder'] = <T, U>(
+export const defaultResponder: ICompellerOptions['responder'] = <T, U, V>(
   statusCode: T,
-  body: U
-) => ({
+  body: U,
+  headers?: V
+): {
+  statusCode: T;
+  body: U;
+  headers?: V;
+} => ({
   statusCode,
   body,
+  headers,
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "@tsconfig/node14",
-  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "include": ["src/**/*.ts", "__tests__/**/*.ts", "examples/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,
     "strict": true,
-    "incremental": true
+    "incremental": true,
+    "noEmit": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node14",
   "include": ["src/**/*.ts", "__tests__/**/*.ts", "examples/**/*.ts"],
+  "exclude": ["examples/with-cdk/**/*.ts"],
   "compilerOptions": {
     "outDir": "./dist",
     "declaration": true,

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["__tests__/**/*.ts"]
+  "exclude": ["__tests__/**/*.ts", "examples/**/*.ts"],
+  "compilerOptions": {
+    "noEmit": false
+  }
 }


### PR DESCRIPTION
Response headers are necessary in order to declare content type.

From this perspective, we need to have an additional consideration.

When content-type is `application/json` we should be sending a default header for that, but that is a bit of a reach, the library isn't really for that. Instead, we should enforce the typing of such headers, and make the user meet the contract.

If they wished to always provide that header, they could do so with a custom responder that returns that header.