### PR TITLE
feat: Add CLI for compeller `add` to support path, method based construction of the schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
-
+coverage
 dist
+src/openapi
 
 *.tgz
 

--- a/_templates/compeller/add/path.ejs.t
+++ b/_templates/compeller/add/path.ejs.t
@@ -1,0 +1,22 @@
+---
+to: <%= directory %>/openapi/paths/<%= h.inflection.dasherize(h.inflection.underscore( name )) %>.path.ts
+---
+import { <%= h.inflection.classify( name )%>Schema } from '../components/schemas/<%= h.inflection.dasherize(h.inflection.underscore( name )) %>.schema'
+
+export const path = {
+  '<%= path %>': {
+    <%= method %>: {
+      responses: {
+        200: {
+          description: 'Get the current API version',
+          content: {
+            'application/json': {
+              schema: <%= h.inflection.classify( name )%>Schema,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+

--- a/_templates/compeller/add/prompt.js
+++ b/_templates/compeller/add/prompt.js
@@ -1,0 +1,21 @@
+// see types of prompts:
+// https://github.com/enquirer/enquirer/tree/master/examples
+//
+module.exports = [
+  {
+    type: 'input',
+    name: 'directory',
+    message: 'Where to store the openapi?',
+    initial: 'src',
+  },
+  {
+    type: 'input',
+    name: 'path',
+    message: 'Fully qualified path e.g. /v1/user',
+  },
+  {
+    type: 'select',
+    name: 'method',
+    choices: ['get', 'put', 'post', 'delete'],
+  },
+];

--- a/_templates/compeller/add/schema.ejs.t
+++ b/_templates/compeller/add/schema.ejs.t
@@ -1,0 +1,10 @@
+---
+to: <%= directory %>/openapi/components/schemas/<%= h.inflection.dasherize(h.inflection.underscore( name )) %>.schema.ts
+unless_exists: true
+---
+import { FromSchema } from 'json-schema-to-ts';
+
+export const <%= h.inflection.classify( name )%>Schema = {} as const;
+
+export type <%= h.inflection.classify( name )%> = FromSchema<typeof <%= h.inflection.classify( name )%>Schema>;
+

--- a/_templates/compeller/new/spec.ejs.t
+++ b/_templates/compeller/new/spec.ejs.t
@@ -1,7 +1,7 @@
 ---
 to: <%= directory %>/openapi/spec.ts
 ---
-import { VersionSchema } from './schemas/version.schema';
+import { versionPath } from './paths/version.path';
 
 export const OpenAPISpecification = {
   info: {
@@ -10,19 +10,6 @@ export const OpenAPISpecification = {
   },
   openapi: '3.1.0',
   paths: {
-    'v1/version': {
-      get: {
-        responses: {
-          '200': {
-            description: 'Get the current API version',
-            content: {
-              'application/json': {
-                schema: VersionSchema,
-              },
-            },
-          },
-        },
-      },
-    },
+    ...versionPath
   },
 };

--- a/_templates/compeller/new/version-path.ejs.t
+++ b/_templates/compeller/new/version-path.ejs.t
@@ -1,0 +1,21 @@
+---
+to: <%= directory %>/openapi/paths/version.path.ts
+---
+import { VersionSchema } from '../components/schemas/version.schema';
+
+export const versionPath = {
+  'v1/version': {
+    get: {
+      responses: {
+        '200': {
+          description: 'Get the current API version',
+          content: {
+            'application/json': {
+              schema: VersionSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/_templates/compeller/new/version.ejs.t
+++ b/_templates/compeller/new/version.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: <%= directory %>/openapi/schemas/version.schema.ts
+to: <%= directory %>/openapi/components/schemas/version.schema.ts
 ---
 import { FromSchema } from 'json-schema-to-ts';
 


### PR DESCRIPTION
This PR introduces:

```
yarn compeller add createUser --path /v1/user --method post
```

A command for injection of a new path with an associated schema.

The injection will ultimately lead to requiring expansion, to support the full API, and this will be problematic, as we are currently only allowing path and method.

The suggestion would be to enable for a fast MVP creation of common scenarios.

### Resource

Assumes something like a rails resource for a restful model

```bash
yarn compeller resource v1/users
```

Which adds opinionated JSON return types for the path:

- get /v1/users with 200 code, 403 code
- get /v1/users/{id} with 200 code, 404 code, 403 code
- post /v1/users with 201 code, 422 code, 403 code
- delete /v1/users/{id} with 204 code, 403 code, 404 code

And would create a schema for NewUser, User, and potential Users as a list, but this would be coupled to User model.

### Todo

- [ ] Support injection fully, for existing files
- [ ] Develop a testing methodology for compeller behaviors to enable integration testing of injection
  - [ ] For example, repeated running should be idempotent.
  - [ ] For example injection into paths with an existing method should be supported. 

### Justification

Injection can provide rapid development of the JSON schema, whilst also enforcing a convention.

If the convention is sensible, and idiomatic for example, just by building a folder structure, that mirrors the OpenAPI specification, then users will lean into it.

#### Is this open for extension?

Yes, injection/generation allows full flexibility, think of rails routes, or active model

